### PR TITLE
feat(course): implement course service with integration and unit tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      jest-mock-extended:
+        specifier: ^4.0.0
+        version: 4.0.0(@jest/globals@30.2.0)(jest@30.2.0(@types/node@24.5.2))(typescript@5.9.2)
       joi:
         specifier: ^18.0.1
         version: 18.0.1
@@ -1907,6 +1910,13 @@ packages:
     resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-mock-extended@4.0.0:
+    resolution: {integrity: sha512-7BZpfuvLam+/HC+NxifIi9b+5VXj/utUDMPUqrDJehGWVuXPtLS9Jqlob2mJLrI/pg2k1S8DMfKDvEB88QNjaQ==}
+    peerDependencies:
+      '@jest/globals': ^28.0.0 || ^29.0.0 || ^30.0.0
+      jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0 || ^30.0.0
+      typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
+
   jest-mock@30.2.0:
     resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2670,6 +2680,14 @@ packages:
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
+
+  ts-essentials@10.1.1:
+    resolution: {integrity: sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ts-jest@29.4.4:
     resolution: {integrity: sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==}
@@ -4656,6 +4674,13 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-mock-extended@4.0.0(@jest/globals@30.2.0)(jest@30.2.0(@types/node@24.5.2))(typescript@5.9.2):
+    dependencies:
+      '@jest/globals': 30.2.0
+      jest: 30.2.0(@types/node@24.5.2)
+      ts-essentials: 10.1.1(typescript@5.9.2)
+      typescript: 5.9.2
+
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
@@ -5473,6 +5498,10 @@ snapshots:
   toidentifier@1.0.1: {}
 
   triple-beam@1.4.1: {}
+
+  ts-essentials@10.1.1(typescript@5.9.2):
+    optionalDependencies:
+      typescript: 5.9.2
 
   ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@24.5.2))(typescript@5.9.2):
     dependencies:

--- a/postman-collection.json
+++ b/postman-collection.json
@@ -972,6 +972,25 @@
           }
         },
         {
+          "name": "Get Section by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/courses/sections/{{sectionId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "courses",
+                "sections",
+                "{{sectionId}}"
+              ]
+            },
+            "description": "Get a section by ID"
+          }
+        },
+        {
           "name": "Create Section",
           "request": {
             "method": "POST",
@@ -1093,6 +1112,26 @@
               ]
             },
             "description": "Get a lesson by its ID"
+          }
+        },
+        {
+          "name": "List Lessons in Section",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/courses/sections/{{sectionId}}/lessons",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "courses",
+                "sections",
+                "{{sectionId}}",
+                "lessons"
+              ]
+            },
+            "description": "List lessons for a section ordered by 'order'"
           }
         },
         {

--- a/services/course-service/jest.config.js
+++ b/services/course-service/jest.config.js
@@ -1,0 +1,58 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: [
+    '**/__tests__/**/*.test.ts',
+  ],
+  projects: [
+    {
+      displayName: 'unit',
+      testEnvironment: 'node',
+      testMatch: ['**/__tests__/unit/**/*.test.ts'],
+      setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup/mock.setup.ts'],
+      moduleNameMapper: {
+        '^@shared$': '<rootDir>/../../shared/src',
+        '^@shared/(.*)$': '<rootDir>/../../shared/src/$1',
+      },
+      transform: {
+        '^.+\\.ts$': ['ts-jest'],
+      },
+    },
+    {
+      displayName: 'integration',
+      testEnvironment: 'node',
+      testMatch: ['**/__tests__/integration/**/*.test.ts'],
+      setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup/database.setup.ts'],
+      moduleNameMapper: {
+        '^@shared$': '<rootDir>/../../shared/src',
+        '^@shared/(.*)$': '<rootDir>/../../shared/src/$1',
+      },
+      transform: {
+        '^.+\\.ts$': ['ts-jest'],
+      },
+    },
+  ],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/types/**',
+    '!src/server.ts',
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html', 'json-summary'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  verbose: true,
+  forceExit: true,
+  clearMocks: true,
+  resetMocks: true,
+  restoreMocks: true,
+  testTimeout: 30000,
+  maxWorkers: 1, // Run tests serially to avoid DB conflicts
+};

--- a/services/course-service/package.json
+++ b/services/course-service/package.json
@@ -16,14 +16,22 @@
     "db:seed": "tsx prisma/seed.ts",
     "db:reset": "prisma migrate reset",
     "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:unit": "jest --selectProjects unit",
+    "test:integration": "jest --selectProjects integration --runInBand",
+    "test:watch": "jest --watch --selectProjects unit",
+    "test:watch:integration": "jest --watch --selectProjects integration --runInBand",
+    "test:coverage": "jest --coverage",
+    "test:coverage:unit": "jest --selectProjects unit --coverage",
+    "test:coverage:integration": "jest --selectProjects integration --coverage --runInBand",
+    "test:ci": "jest --ci --coverage --maxWorkers=2",
+    "test:verbose": "jest --verbose"
   },
   "dependencies": {
     "@prisma/client": "6.16.1",
     "@shared": "workspace:*",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "jest-mock-extended": "^4.0.0",
     "joi": "^18.0.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"

--- a/services/course-service/prisma/seed.ts
+++ b/services/course-service/prisma/seed.ts
@@ -1,7 +1,5 @@
 import prisma from '../src/db/client';
 
-const prisma = new PrismaClient();
-
 async function main() {
   console.log('Seeding course service database...');
 

--- a/services/course-service/src/__tests__/integration/api/course.api.test.ts
+++ b/services/course-service/src/__tests__/integration/api/course.api.test.ts
@@ -1,0 +1,357 @@
+import request from 'supertest';
+// Ensure DB is configured before importing the app
+import { setupTestDatabase, teardownTestDatabase, clearDatabase, prisma } from '../../setup/database.setup';
+import app from '../../../app';
+import { generateAuthToken, createTestCourse, createTestCategory, createFullCourse } from '../../setup/fixtures';
+
+describe('Course API - Integration Tests', () => {
+  let instructorToken: string;
+  let studentToken: string;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    await setupTestDatabase();
+    instructorToken = generateAuthToken(1, 'INSTRUCTOR');
+    studentToken = generateAuthToken(2, 'STUDENT');
+    adminToken = generateAuthToken(3, 'ADMIN');
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+  });
+
+  describe('POST /courses', () => {
+    it('should create course as instructor', async () => {
+      const response = await request(app)
+        .post('/courses')
+        .set('Authorization', `Bearer ${instructorToken}`)
+        .send({
+          title: 'New Course',
+          description: 'Course description',
+          price: 49.99,
+          level: 'BEGINNER',
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.status).toBe('success');
+      expect(response.body.data.course.title).toBe('New Course');
+      expect(response.body.data.course.slug).toBe('new-course');
+
+      // Verify in database
+      const course = await prisma.course.findUnique({
+        where: { id: response.body.data.course.id },
+      });
+      expect(course).toBeDefined();
+      expect(course?.title).toBe('New Course');
+    });
+
+    it('should reject invalid data', async () => {
+      const response = await request(app)
+        .post('/courses')
+        .set('Authorization', `Bearer ${instructorToken}`)
+        .send({
+          title: 'AB', // Too short
+        });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should reject student role', async () => {
+      const response = await request(app)
+        .post('/courses')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({ title: 'Test Course' });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('GET /courses', () => {
+    it('should return published courses', async () => {
+      await createTestCourse(prisma, 1, { status: 'PUBLISHED' });
+      await createTestCourse(prisma, 1, { status: 'PUBLISHED' });
+      await createTestCourse(prisma, 1, { status: 'DRAFT' }); // Should not appear
+
+      const response = await request(app).get('/courses');
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.courses).toHaveLength(2);
+      expect(response.body.data.pagination.total).toBe(2);
+    });
+
+    it('should filter by category', async () => {
+      const category = await createTestCategory(prisma);
+      await createTestCourse(prisma, 1, { categoryId: category.id, status: 'PUBLISHED' });
+      await createTestCourse(prisma, 1, { status: 'PUBLISHED' });
+
+      const response = await request(app)
+        .get('/courses')
+        .query({ categoryId: category.id });
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.courses).toHaveLength(1);
+      expect(response.body.data.courses[0].categoryId).toBe(category.id);
+    });
+
+    it('should search courses', async () => {
+      await createTestCourse(prisma, 1, { title: 'React Advanced', status: 'PUBLISHED' });
+      await createTestCourse(prisma, 1, { title: 'Node.js Basics', status: 'PUBLISHED' });
+
+      const response = await request(app)
+        .get('/courses')
+        .query({ search: 'react' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.courses).toHaveLength(1);
+      expect(response.body.data.courses[0].title).toContain('React');
+    });
+  });
+
+  describe('PUT /courses/:id', () => {
+    it('should update course as owner', async () => {
+      const course = await createTestCourse(prisma, 1);
+
+      const response = await request(app)
+        .put(`/courses/${course.id}`)
+        .set('Authorization', `Bearer ${instructorToken}`)
+        .send({
+          title: 'Updated Title',
+          price: 99.99,
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.course.title).toBe('Updated Title');
+      expect(response.body.data.course.price).toBe(99.99);
+
+      // Verify in database
+      const updated = await prisma.course.findUnique({
+        where: { id: course.id },
+      });
+      expect(updated?.title).toBe('Updated Title');
+    });
+
+    it('should reject non-owner', async () => {
+      const course = await createTestCourse(prisma, 5); // Different instructor
+
+      const response = await request(app)
+        .put(`/courses/${course.id}`)
+        .set('Authorization', `Bearer ${instructorToken}`)
+        .send({ title: 'Hacked' });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('POST /courses/:id/publish', () => {
+    it('should publish course with content', async () => {
+      const { course } = await createFullCourse(prisma, 1);
+
+      const response = await request(app)
+        .post(`/courses/${course.id}/publish`)
+        .set('Authorization', `Bearer ${instructorToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.course.status).toBe('PUBLISHED');
+
+      // Verify in database
+      const published = await prisma.course.findUnique({
+        where: { id: course.id },
+      });
+      expect(published?.status).toBe('PUBLISHED');
+    });
+
+    it('should reject course without content', async () => {
+      const course = await createTestCourse(prisma, 1);
+
+      const response = await request(app)
+        .post(`/courses/${course.id}/publish`)
+        .set('Authorization', `Bearer ${instructorToken}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('without content');
+    });
+  });
+
+  describe('POST /courses/enrollments', () => {
+    it('should enroll in published course', async () => {
+      const course = await createTestCourse(prisma, 1, { status: 'PUBLISHED' });
+
+      const response = await request(app)
+        .post('/courses/enrollments')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({ courseId: course.id });
+
+      expect(response.status).toBe(201);
+      expect(response.body.data.enrollment.courseId).toBe(course.id);
+      expect(response.body.data.enrollment.userId).toBe(2);
+
+      // Verify in database
+      const enrollment = await prisma.enrollment.findUnique({
+        where: {
+          userId_courseId: { userId: 2, courseId: course.id },
+        },
+      });
+      expect(enrollment).toBeDefined();
+      expect(enrollment?.status).toBe('ACTIVE');
+    });
+
+    it('should reject unpublished course', async () => {
+      const course = await createTestCourse(prisma, 1, { status: 'DRAFT' });
+
+      const response = await request(app)
+        .post('/courses/enrollments')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({ courseId: course.id });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('Categories', () => {
+    describe('POST /courses/categories', () => {
+      it('should create category as admin', async () => {
+        const response = await request(app)
+          .post('/courses/categories')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({
+            name: 'Programming',
+            description: 'Programming courses',
+          });
+
+        expect(response.status).toBe(201);
+        expect(response.body.data.category.name).toBe('Programming');
+        expect(response.body.data.category.slug).toBe('programming');
+
+        // Verify in database
+        const category = await prisma.category.findUnique({
+          where: { slug: 'programming' },
+        });
+        expect(category).toBeDefined();
+      });
+
+      it('should reject non-admin', async () => {
+        const response = await request(app)
+          .post('/courses/categories')
+          .set('Authorization', `Bearer ${instructorToken}`)
+          .send({ name: 'Test' });
+
+        expect(response.status).toBe(403);
+      });
+    });
+
+    describe('DELETE /courses/categories/:id', () => {
+      it('should prevent deleting category with courses', async () => {
+        const category = await createTestCategory(prisma);
+        await createTestCourse(prisma, 1, { categoryId: category.id });
+
+        const response = await request(app)
+          .delete(`/courses/categories/${category.id}`)
+          .set('Authorization', `Bearer ${adminToken}`);
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toContain('with courses');
+
+        // Verify still in database
+        const stillExists = await prisma.category.findUnique({
+          where: { id: category.id },
+        });
+        expect(stillExists).toBeDefined();
+      });
+    });
+  });
+
+  describe('Complex Scenarios', () => {
+    it('should handle complete course lifecycle', async () => {
+      // 1. Create course
+      const createResponse = await request(app)
+        .post('/courses')
+        .set('Authorization', `Bearer ${instructorToken}`)
+        .send({
+          title: 'Complete Course',
+          price: 49.99,
+        });
+
+      const courseId = createResponse.body.data.course.id;
+
+      // 2. Add section
+      const sectionResponse = await request(app)
+        .post('/courses/sections')
+        .set('Authorization', `Bearer ${instructorToken}`)
+        .send({
+          courseId,
+          title: 'Section 1',
+        });
+
+      const sectionId = sectionResponse.body.data.section.id;
+
+      // 3. Add lesson
+      await request(app)
+        .post('/courses/lessons')
+        .set('Authorization', `Bearer ${instructorToken}`)
+        .send({
+          sectionId,
+          title: 'Lesson 1',
+          type: 'VIDEO',
+        });
+
+      // 4. Publish course
+      const publishResponse = await request(app)
+        .post(`/courses/${courseId}/publish`)
+        .set('Authorization', `Bearer ${instructorToken}`);
+
+      expect(publishResponse.status).toBe(200);
+
+      // 5. Student enrolls
+      const enrollResponse = await request(app)
+        .post('/courses/enrollments')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({ courseId });
+
+      expect(enrollResponse.status).toBe(201);
+
+      // Verify complete flow in database
+      const finalCourse = await prisma.course.findUnique({
+        where: { id: courseId },
+        include: {
+          sections: {
+            include: { lessons: true },
+          },
+          enrollments: true,
+        },
+      });
+
+      expect(finalCourse?.status).toBe('PUBLISHED');
+      expect(finalCourse?.sections).toHaveLength(1);
+      expect(finalCourse?.sections[0].lessons).toHaveLength(1);
+      expect(finalCourse?.enrollments).toHaveLength(1);
+    });
+
+    it('should handle cascading deletes', async () => {
+      const { course, section, lesson } = await createFullCourse(prisma, 1);
+
+      // Delete course
+      await request(app)
+        .delete(`/courses/${course.id}`)
+        .set('Authorization', `Bearer ${instructorToken}`);
+
+      // Verify cascading delete
+      const deletedCourse = await prisma.course.findUnique({
+        where: { id: course.id },
+      });
+      const deletedSection = await prisma.section.findUnique({
+        where: { id: section.id },
+      });
+      const deletedLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+
+      expect(deletedCourse).toBeNull();
+      expect(deletedSection).toBeNull();
+      expect(deletedLesson).toBeNull();
+    });
+  });
+});

--- a/services/course-service/src/__tests__/integration/api/queries.test.ts
+++ b/services/course-service/src/__tests__/integration/api/queries.test.ts
@@ -1,0 +1,178 @@
+import { setupTestDatabase, teardownTestDatabase, clearDatabase, prisma } from '../../setup/database.setup';
+import { createTestCourse, createTestCategory, createTestSection, createTestLesson } from '../../setup/fixtures';
+
+describe('Database Queries - Integration Tests', () => {
+  beforeAll(async () => {
+    await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+  });
+
+  describe('Complex Queries', () => {
+    it('should query courses with nested relations', async () => {
+      const category = await createTestCategory(prisma);
+      const course = await createTestCourse(prisma, 1, { categoryId: category.id });
+      const section = await createTestSection(prisma, course.id);
+      await createTestLesson(prisma, section.id);
+
+      const result = await prisma.course.findUnique({
+        where: { id: course.id },
+        include: {
+          category: true,
+          sections: {
+            include: {
+              lessons: true,
+            },
+          },
+        },
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.category).toBeDefined();
+      expect(result?.sections).toHaveLength(1);
+      expect(result?.sections[0].lessons).toHaveLength(1);
+    });
+
+    it('should handle unique constraint violations', async () => {
+      const category = await createTestCategory(prisma, { slug: 'unique-slug' });
+
+      await expect(
+        createTestCategory(prisma, { slug: 'unique-slug' })
+      ).rejects.toThrow();
+    });
+
+    it('should perform aggregations', async () => {
+      await createTestCourse(prisma, 1, { price: 10 });
+      await createTestCourse(prisma, 1, { price: 20 });
+      await createTestCourse(prisma, 1, { price: 30 });
+
+      const result = await prisma.course.aggregate({
+        _avg: { price: true },
+        _max: { price: true },
+        _min: { price: true },
+        _sum: { price: true },
+      });
+
+      expect(result._avg.price).toBe(20);
+      expect(result._max.price).toBe(30);
+      expect(result._min.price).toBe(10);
+      expect(result._sum.price).toBe(60);
+    });
+
+    it('should handle transactions', async () => {
+      const category = await createTestCategory(prisma);
+
+      await prisma.$transaction(async (tx) => {
+        const course1 = await tx.course.create({
+          data: {
+            title: 'Course 1',
+            slug: 'course-1',
+            instructorId: 1,
+            categoryId: category.id,
+          },
+        });
+
+        const course2 = await tx.course.create({
+          data: {
+            title: 'Course 2',
+            slug: 'course-2',
+            instructorId: 1,
+            categoryId: category.id,
+          },
+        });
+
+        expect(course1).toBeDefined();
+        expect(course2).toBeDefined();
+      });
+
+      const courses = await prisma.course.findMany();
+      expect(courses).toHaveLength(2);
+    });
+
+    it('should rollback failed transactions', async () => {
+      await expect(
+        prisma.$transaction(async (tx) => {
+          await tx.course.create({
+            data: {
+              title: 'Course 1',
+              slug: 'course-1',
+              instructorId: 1,
+            },
+          });
+
+          // This will fail (duplicate slug)
+          await tx.course.create({
+            data: {
+              title: 'Course 2',
+              slug: 'course-1', // Duplicate!
+              instructorId: 1,
+            },
+          });
+        })
+      ).rejects.toThrow();
+
+      // Verify rollback
+      const courses = await prisma.course.findMany();
+      expect(courses).toHaveLength(0);
+    });
+  });
+
+  describe('Performance Tests', () => {
+    it('should efficiently query with indexes', async () => {
+      // Create test data
+      for (let i = 0; i < 50; i++) {
+        await createTestCourse(prisma, 1, { status: 'PUBLISHED' });
+      }
+
+      const start = Date.now();
+      
+      // Query should use index on status
+      const courses = await prisma.course.findMany({
+        where: { status: 'PUBLISHED' },
+        take: 10,
+      });
+
+      const duration = Date.now() - start;
+
+      expect(courses).toHaveLength(10);
+      expect(duration).toBeLessThan(100); // Should be fast with index
+    });
+
+    it('should handle pagination efficiently', async () => {
+      // Create 100 courses
+      const promises = [];
+      for (let i = 0; i < 100; i++) {
+        promises.push(
+          createTestCourse(prisma, 1, { 
+            title: `Course ${i}`,
+            slug: `course-${i}`,
+          })
+        );
+      }
+      await Promise.all(promises);
+
+      // Page through results
+      const page1 = await prisma.course.findMany({
+        take: 20,
+        skip: 0,
+        orderBy: { id: 'asc' },
+      });
+
+      const page2 = await prisma.course.findMany({
+        take: 20,
+        skip: 20,
+        orderBy: { id: 'asc' },
+      });
+
+      expect(page1).toHaveLength(20);
+      expect(page2).toHaveLength(20);
+      expect(page1[0].id).not.toBe(page2[0].id);
+    });
+  });
+});

--- a/services/course-service/src/__tests__/setup/database.setup.ts
+++ b/services/course-service/src/__tests__/setup/database.setup.ts
@@ -1,0 +1,55 @@
+import { PrismaClient } from "@prisma/client";
+import { execSync } from "child_process";
+import { randomBytes } from "crypto";
+
+const generateDatabaseUrl = () => {
+  const schema = `test_${randomBytes(8).toString('hex')}`;
+  const baseUrl = process.env.DATABASE_URL || `postgresql://course_service:course_password@localhost:5434/course_service`;
+  const url = new URL(baseUrl);
+  url.searchParams.set('schema', schema)
+  return url.toString();
+};
+
+export const testDatabaseUrl = generateDatabaseUrl();
+process.env.DATABASE_URL = testDatabaseUrl;
+
+export const prisma = new PrismaClient({
+  datasources: {
+    db: {
+      url: testDatabaseUrl,
+    },
+  },
+  log: process.env.LOG_LEVEL === 'debug' ? ['query', 'error', 'warn'] : ['error'],
+});
+
+export const setupTestDatabase = async () => {
+  execSync('npx prisma db push --skip-generate', {
+    env: {
+      ...process.env,
+      DATABASE_URL: testDatabaseUrl
+    },
+    stdio: 'ignore'
+  });
+
+  return prisma;
+};
+
+export const teardownTestDatabase = async () => {
+  // Drop test schema
+  const url = new URL(testDatabaseUrl);
+  const schema = url.searchParams.get('schema');
+
+  if (schema && schema.startsWith('test_')) {
+    await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  }
+
+  await prisma.$disconnect();
+};
+
+export const clearDatabase = async () => {
+  const tables = ['enrollments', 'lessons', 'sections', 'courses', 'categories'];
+
+  for (const table of tables) {
+    await prisma.$executeRawUnsafe(`TRUNCATE TABLE "${table}" RESTART IDENTITY CASCADE`);
+  }
+};

--- a/services/course-service/src/__tests__/setup/fixtures.ts
+++ b/services/course-service/src/__tests__/setup/fixtures.ts
@@ -1,0 +1,171 @@
+import { PrismaClient, CourseLevel, CourseStatus, LessonType } from "@prisma/client";
+import { signAccessToken } from "@shared/middlewares/auth";
+
+export const createTestUser = (id: number, role: 'STUDENT' | 'INSTRUCTOR' | 'ADMIN' = 'STUDENT') => {
+  return {
+    id,
+    email: `test${id}@example.com`,
+    role
+  }
+}
+
+export const generateAuthToken = (userId: number, role: 'STUDENT' | 'INSTRUCTOR' | 'ADMIN' = 'STUDENT') => {
+  const user = createTestUser(userId, role);
+  return signAccessToken(user as any)
+}
+
+export const createTestCategory = async (prisma: PrismaClient, data?: Partial<any>) => {
+  return await prisma.category.create({
+    data: {
+      name: data?.name || 'Test Category',
+      slug: data?.slug || `test-category-${Date.now()}`,
+      description: data?.description || 'Test category description',
+      ...data
+    }
+  })
+}
+
+export const createTestCourse = async (
+  prisma: PrismaClient,
+  instructorId: number = 1,
+  data?: Partial<any>
+) => {
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return await prisma.course.create({
+    data: {
+      title: data?.title || 'Test Course',
+      slug: data?.slug || `test-course-${uniqueSuffix}`,
+      description: data?.description || 'Test course description',
+      price: data?.price ?? 49.99,
+      currency: data?.currency || 'USD',
+      instructorId,
+      level: data?.level || CourseLevel.BEGINNER,
+      status: data?.status || CourseStatus.DRAFT,
+      tags: data?.tags || ['test'],
+      requirements: data?.requirements || [],
+      objectives: data?.objectives || [],
+      ...data,
+    },
+  })
+}
+
+export const createTestSection = async (
+  prisma: PrismaClient,
+  courseId: number,
+  data?: Partial<any>
+) => {
+  return await prisma.section.create({
+    data: {
+      courseId,
+      title: data?.title || 'Test Section',
+      description: data?.description || 'Test section description',
+      order: data?.order ?? 0,
+      ...data,
+    },
+  });
+};
+
+export const createTestLesson = async (
+  prisma: PrismaClient,
+  sectionId: number,
+  data?: Partial<any>
+) => {
+  return await prisma.lesson.create({
+    data: {
+      sectionId,
+      title: data?.title || 'Test Lesson',
+      description: data?.description || 'Test lesson description',
+      type: data?.type || LessonType.VIDEO,
+      content: data?.content || 'https://example.com/video.mp4',
+      duration: data?.duration ?? 300,
+      order: data?.order ?? 0,
+      isFree: data?.isFree ?? false,
+      ...data,
+    },
+  });
+};
+
+export const createTestEnrollment = async (
+  prisma: PrismaClient,
+  userId: number,
+  courseId: number,
+  data?: Partial<any>
+) => {
+  return await prisma.enrollment.create({
+    data: {
+      userId,
+      courseId,
+      status: data?.status || 'ACTIVE',
+      progress: data?.progress ?? 0,
+      ...data,
+    },
+  });
+};
+
+export const createFullCourse = async (
+  prisma: PrismaClient,
+  instructorId: number = 1
+) => {
+  const course = await createTestCourse(prisma, instructorId);
+  const section = await createTestSection(prisma, course.id);
+  const lesson = await createTestLesson(prisma, section.id);
+
+  return { course, section, lesson };
+}
+
+export const mockCourse = (overrides?: Partial<any>) => ({
+  id: 1,
+  title: 'Mock Course',
+  slug: 'mock-course',
+  description: 'Mock description',
+  thumbnail: null,
+  price: 49.99,
+  currency: 'USD',
+  instructorId: 1,
+  categoryId: null,
+  level: CourseLevel.BEGINNER,
+  status: CourseStatus.DRAFT,
+  language: 'en',
+  duration: 0,
+  tags: [],
+  requirements: [],
+  objectives: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+})
+
+export const mockCategory = (overrides?: Partial<any>) => ({
+  id: 1,
+  name: 'Mock Category',
+  slug: 'mock-category',
+  description: 'Mock description',
+  icon: null,
+  parentId: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+})
+
+export const mockSection = (overrides?: Partial<any>) => ({
+  id: 1,
+  courseId: 1,
+  title: 'Mock Section',
+  description: 'Mock description',
+  order: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+})
+
+export const mockEnrollment = (overrides?: Partial<any>) => ({
+  id: 1,
+  userId: 1,
+  courseId: 1,
+  status: 'ACTIVE' as const,
+  progress: 0,
+  completedAt: null,
+  enrolledAt: new Date(),
+  lastAccessedAt: null,
+  ...overrides,
+});

--- a/services/course-service/src/__tests__/setup/mock.setup.ts
+++ b/services/course-service/src/__tests__/setup/mock.setup.ts
@@ -1,0 +1,41 @@
+import { PrismaClient } from "@prisma/client";
+import { DeepMockProxy, mockDeep, mockReset } from "jest-mock-extended";
+
+export type MockPrismaClient = DeepMockProxy<PrismaClient>;
+
+export const mockPrisma: MockPrismaClient = mockDeep<PrismaClient>();
+
+beforeEach(() => {
+  mockReset(mockPrisma);
+});
+
+jest.mock('../../db/client', () => ({
+  __esModule: true,
+  get default() {
+    return mockPrisma;
+  }
+}));
+
+jest.mock('@shared', () => {
+  const actual = jest.requireActual('@shared');
+  return {
+    ...actual,
+    getRedis: jest.fn(() => ({
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+      del: jest.fn().mockResolvedValue(1),
+      scanStream: jest.fn(() => ({
+        [Symbol.asyncIterator]: async function*() {
+          yield [];
+        }
+      })),
+      pipeline: jest.fn(() => ({
+        del: jest.fn(),
+        exec: jest.fn().mockResolvedValue([])
+      })),
+      ping: jest.fn().mockResolvedValue('PONG')
+    })),
+    connectRedis: jest.fn().mockResolvedValue(undefined),
+    quitRedis: jest.fn().mockResolvedValue(undefined)
+  }
+})

--- a/services/course-service/src/__tests__/unit/services/category.service.test.ts
+++ b/services/course-service/src/__tests__/unit/services/category.service.test.ts
@@ -1,0 +1,82 @@
+import { mockPrisma } from '../../setup/mock.setup';
+import * as categoryService from '../../../services/category.service'
+import { mockCategory, mockCourse } from '../../setup/fixtures';
+
+describe('Category Service - Unit Tests', () => {
+  describe('createCategory', () => {
+    it('should create category with generated slug', async () => {
+      const categoryData = {
+        name: 'Web Development',
+        description: 'Web dev courses',
+      };
+
+      const expectedCategory = mockCategory({
+        name: 'Web Development',
+        slug: 'web-development',
+      });
+
+      mockPrisma.category.findUnique.mockResolvedValue(null); // Slug available
+      mockPrisma.category.create.mockResolvedValue(expectedCategory as any);
+
+      const result = await categoryService.createCategory(categoryData);
+
+      expect(mockPrisma.category.create).toHaveBeenCalled();
+      expect(result.name).toBe('Web Development');
+    });
+
+    it('should validate parent exists', async () => {
+      const categoryData = {
+        name: 'Frontend',
+        parentId: 1,
+      };
+
+      mockPrisma.category.findUnique
+        .mockResolvedValueOnce(null) // Slug check
+        .mockResolvedValueOnce(null); // Parent not found
+
+      await expect(
+        categoryService.createCategory(categoryData)
+      ).rejects.toThrow('Parent category not found');
+    });
+  });
+
+  describe('updateCategory', () => {
+    it('should prevent self as parent', async () => {
+      const category = mockCategory({ id: 1 });
+      mockPrisma.category.findUnique.mockResolvedValue(category as any);
+
+      await expect(
+        categoryService.updateCategory(1, { parentId: 1 })
+      ).rejects.toThrow('cannot be its own parent');
+    });
+  });
+
+  describe('deleteCategory', () => {
+    it('should prevent deleting category with children', async () => {
+      const category = mockCategory({
+        id: 1,
+        children: [mockCategory({ id: 2 })],
+      });
+
+      mockPrisma.category.findUnique.mockResolvedValue(category as any);
+
+      await expect(
+        categoryService.deleteCategory(1)
+      ).rejects.toThrow('with subcategories');
+    });
+
+    it('should prevent deleting category with courses', async () => {
+      const category = mockCategory({
+        id: 1,
+        children: [],
+        courses: [mockCourse({ id: 1 })],
+      });
+
+      mockPrisma.category.findUnique.mockResolvedValue(category as any);
+
+      await expect(
+        categoryService.deleteCategory(1)
+      ).rejects.toThrow('with courses');
+    });
+  });
+});

--- a/services/course-service/src/__tests__/unit/services/course.service.test.ts
+++ b/services/course-service/src/__tests__/unit/services/course.service.test.ts
@@ -1,0 +1,234 @@
+import * as courseService from '../../../services/course.service';
+import { mockCourse } from '../../setup/fixtures';
+import { mockPrisma } from '../../setup/mock.setup';
+
+describe('Course Service - Unit Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('createCourse', () => {
+    it('should create course with valid data', async () => {
+      const courseData = {
+        title: 'Node.js Masterclass',
+        description: 'Learn Node.js',
+        price: 49.99,
+        level: 'BEGINNER' as any,
+      };
+
+      const expectedCourse = mockCourse({
+        title: 'Node.js Masterclass',
+        slug: 'nodejs-masterclass',
+      });
+
+      mockPrisma.course.findUnique.mockResolvedValue(expectedCourse as any)
+
+      mockPrisma.course.create.mockResolvedValue(expectedCourse);
+
+      const result = await courseService.createCourse(1, courseData);
+
+      expect(mockPrisma.course.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          title: 'Node.js Masterclass',
+          instructorId: 1,
+          tags: [],
+          requirements: [],
+          objectives: [],
+        }),
+        include: expect.any(Object),
+      });
+
+      expect(result.title).toBe('Node.js Masterclass');
+    });
+
+    it('should set default values', async () => {
+      const courseData = { title: 'Test Course' };
+      const expectedCourse = mockCourse();
+
+      mockPrisma.course.create.mockResolvedValue(expectedCourse);
+
+      await courseService.createCourse(1, courseData);
+
+      expect(mockPrisma.course.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          tags: [],
+          requirements: [],
+          objectives: [],
+        }),
+        include: expect.any(Object),
+      });
+    });
+  });
+
+  describe('getCourseById', () => {
+    it('should return course when found', async () => {
+      const course = mockCourse({ id: 1 });
+      mockPrisma.course.findUnique.mockResolvedValue(course as any);
+
+      const result = await courseService.getCourseById(1);
+
+      expect(mockPrisma.course.findUnique).toHaveBeenCalledWith({
+        where: { id: 1 },
+        include: expect.any(Object),
+      });
+      expect(result).toEqual(course);
+    });
+
+    it('should return null when not found', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(null);
+
+      const result = await courseService.getCourseById(99999);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateCourse', () => {
+    it('should update course when user is owner', async () => {
+      const existingCourse = mockCourse({ id: 1, instructorId: 1 });
+      const updatedCourse = mockCourse({ id: 1, title: 'Updated Title' });
+
+      mockPrisma.course.findUnique.mockResolvedValue(existingCourse as any);
+      mockPrisma.course.update.mockResolvedValue(updatedCourse as any);
+
+      const { updated } = await courseService.updateCourse(1, 1, { title: 'Updated Title' });
+
+      expect(mockPrisma.course.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: expect.objectContaining({ title: 'Updated Title' }),
+        include: expect.any(Object),
+      });
+      expect(updated.title).toBe('Updated Title');
+    });
+
+    it('should throw error when course not found', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(null);
+
+      await expect(
+        courseService.updateCourse(999, 1, { title: 'Test' })
+      ).rejects.toThrow('Course not found');
+    });
+
+    it('should throw error when user is not owner', async () => {
+      const course = mockCourse({ id: 1, instructorId: 2 });
+      mockPrisma.course.findUnique.mockResolvedValue(course as any);
+
+      await expect(
+        courseService.updateCourse(1, 1, { title: 'Hacked' })
+      ).rejects.toThrow('Not authorized');
+    });
+  });
+
+  describe('deleteCourse', () => {
+    it('should delete course when user is owner', async () => {
+      const course = mockCourse({ id: 1, instructorId: 1 });
+      mockPrisma.course.findUnique.mockResolvedValue(course as any);
+      mockPrisma.course.delete.mockResolvedValue(course as any);
+
+      await courseService.deleteCourse(1, 1);
+
+      expect(mockPrisma.course.delete).toHaveBeenCalledWith({
+        where: { id: 1 },
+      });
+    });
+
+    it('should throw error when not owner', async () => {
+      const course = mockCourse({ id: 1, instructorId: 2 });
+      mockPrisma.course.findUnique.mockResolvedValue(course as any);
+
+      await expect(
+        courseService.deleteCourse(1, 1)
+      ).rejects.toThrow('Not authorized');
+
+      expect(mockPrisma.course.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAllCourses', () => {
+    it('should return paginated courses', async () => {
+      const courses = [mockCourse({ id: 1 }), mockCourse({ id: 2 })];
+
+      mockPrisma.course.findMany.mockResolvedValue(courses as any);
+      mockPrisma.course.count.mockResolvedValue(2);
+
+      const result = await courseService.getAllCourses({ page: 1, limit: 10 });
+
+      expect(result.courses).toHaveLength(2);
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 10,
+        total: 2,
+        pages: 1,
+      });
+    });
+
+    it('should filter by status', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([]);
+      mockPrisma.course.count.mockResolvedValue(0);
+
+      await courseService.getAllCourses({ status: 'PUBLISHED' as any });
+
+      expect(mockPrisma.course.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: 'PUBLISHED' }),
+        })
+      );
+    });
+
+    it('should filter by category', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([]);
+      mockPrisma.course.count.mockResolvedValue(0);
+
+      await courseService.getAllCourses({ categoryId: 1 });
+
+      expect(mockPrisma.course.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ categoryId: 1 }),
+        })
+      );
+    });
+  });
+
+  describe('publishCourse', () => {
+    it('should publish course with content', async () => {
+      const course = mockCourse({
+        id: 1,
+        instructorId: 1,
+        sections: [
+          {
+            id: 1,
+            lessons: [{ id: 1 }],
+          },
+        ],
+      });
+
+      const publishedCourse = mockCourse({ id: 1, status: 'PUBLISHED' as any });
+
+      mockPrisma.course.findUnique.mockResolvedValue(course as any);
+      mockPrisma.course.update.mockResolvedValue(publishedCourse as any);
+
+      const result = await courseService.publishCourse(1, 1);
+
+      expect(result.status).toBe('PUBLISHED');
+      expect(mockPrisma.course.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { status: 'PUBLISHED' },
+        include: expect.any(Object),
+      });
+    });
+
+    it('should throw error when no content', async () => {
+      const course = mockCourse({
+        id: 1,
+        instructorId: 1,
+        sections: [], // No sections
+      });
+
+      mockPrisma.course.findUnique.mockResolvedValue(course as any);
+
+      await expect(
+        courseService.publishCourse(1, 1)
+      ).rejects.toThrow('Cannot publish course without content');
+    });
+  });
+});

--- a/services/course-service/src/__tests__/unit/services/enrollment.service.test.ts
+++ b/services/course-service/src/__tests__/unit/services/enrollment.service.test.ts
@@ -1,0 +1,81 @@
+import { mockPrisma } from '../../setup/mock.setup';
+import * as enrollmentService from '../../../services/enrollment.service';
+
+describe('Enrollment Service - Unit Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createEnrollment', () => {
+    it('should create when course is published and not enrolled', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 1, status: 'PUBLISHED' } as any);
+      mockPrisma.enrollment.findUnique.mockResolvedValue(null as any);
+      mockPrisma.enrollment.create.mockResolvedValue({ id: 1, userId: 1, courseId: 1 } as any);
+
+      const res = await enrollmentService.createEnrollment({ userId: 1, courseId: 1 });
+      expect(res.id).toBe(1);
+    });
+
+    it('should reactivate dropped enrollment', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 1, status: 'PUBLISHED' } as any);
+      mockPrisma.enrollment.findUnique.mockResolvedValue({ id: 9, status: 'DROPPED', userId: 1, courseId: 1 } as any);
+      mockPrisma.enrollment.update.mockResolvedValue({ id: 9, status: 'ACTIVE' } as any);
+
+      const res = await enrollmentService.createEnrollment({ userId: 1, courseId: 1 });
+      expect(res.status).toBe('ACTIVE');
+    });
+
+    it('should prevent duplicate active enrollment', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 1, status: 'PUBLISHED' } as any);
+      mockPrisma.enrollment.findUnique.mockResolvedValue({ id: 9, status: 'ACTIVE' } as any);
+      await expect(enrollmentService.createEnrollment({ userId: 1, courseId: 1 }))
+        .rejects.toThrow('Already enrolled');
+    });
+
+    it('should reject unpublished course', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 1, status: 'DRAFT' } as any);
+      await expect(enrollmentService.createEnrollment({ userId: 1, courseId: 1 }))
+        .rejects.toThrow('unpublished');
+    });
+
+    it('should reject when course not found', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(null as any);
+      await expect(enrollmentService.createEnrollment({ userId: 1, courseId: 1 }))
+        .rejects.toThrow('Course not found');
+    });
+  });
+
+  describe('updateEnrollment', () => {
+    it('should update progress and set completed when >= 100', async () => {
+      mockPrisma.enrollment.findUnique.mockResolvedValue({ id: 1, userId: 1 } as any);
+      mockPrisma.enrollment.update.mockResolvedValue({ id: 1, progress: 100, status: 'COMPLETED' } as any);
+      const res = await enrollmentService.updateEnrollment(1, 1, { progress: 100 });
+      expect(res.status).toBe('COMPLETED');
+      expect(mockPrisma.enrollment.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'COMPLETED' }) })
+      );
+    });
+
+    it('should forbid updating others enrollment', async () => {
+      mockPrisma.enrollment.findUnique.mockResolvedValue({ id: 1, userId: 2 } as any);
+      await expect(enrollmentService.updateEnrollment(1, 1, { progress: 10 }))
+        .rejects.toThrow('Not authorized');
+    });
+  });
+
+  describe('dropEnrollment', () => {
+    it('should drop enrollment', async () => {
+      mockPrisma.enrollment.findUnique.mockResolvedValue({ id: 1, userId: 1 } as any);
+      mockPrisma.enrollment.update.mockResolvedValue({ id: 1 } as any);
+      await enrollmentService.dropEnrollment(1, 1);
+      expect(mockPrisma.enrollment.update).toHaveBeenCalledWith({ where: { id: 1 }, data: { status: 'DROPPED' } });
+    });
+  });
+
+  describe('helpers', () => {
+    it('isUserEnrolled should return true for active enrollment', async () => {
+      mockPrisma.enrollment.findUnique.mockResolvedValue({ status: 'ACTIVE' } as any);
+      await expect(enrollmentService.isUserEnrolled(1, 1)).resolves.toBe(true);
+    });
+  });
+});

--- a/services/course-service/src/__tests__/unit/services/lesson.service.test.ts
+++ b/services/course-service/src/__tests__/unit/services/lesson.service.test.ts
@@ -1,0 +1,67 @@
+import { mockPrisma } from '../../setup/mock.setup';
+import * as lessonService from '../../../services/lesson.service';
+
+jest.mock('../../../services/course.service', () => ({
+  calculateCourseDuration: jest.fn().mockResolvedValue(0),
+}));
+
+describe('Lesson Service - Unit Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createLesson', () => {
+    it('should create lesson and compute order when missing', async () => {
+      mockPrisma.section.findUnique.mockResolvedValue({ id: 5, course: { id: 10, instructorId: 1 } } as any);
+      mockPrisma.lesson.findFirst.mockResolvedValue(null as any);
+      mockPrisma.lesson.aggregate.mockResolvedValue({ _max: { order: 0 } } as any);
+      mockPrisma.lesson.create.mockResolvedValue({ id: 1, order: 1 } as any);
+
+      const res = await lessonService.createLesson(1, { sectionId: 5, title: 'L1', type: 'VIDEO' } as any);
+      expect(res.id).toBe(1);
+      expect(mockPrisma.lesson.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ order: 1 }) })
+      );
+    });
+
+    it('should reject when not section owner', async () => {
+      mockPrisma.section.findUnique.mockResolvedValue({ course: { instructorId: 2 } } as any);
+      await expect(lessonService.createLesson(1, { sectionId: 5, title: 'L1', type: 'VIDEO' } as any))
+        .rejects.toThrow('Not authorized');
+    });
+
+    it('should reject when section not found', async () => {
+      mockPrisma.section.findUnique.mockResolvedValue(null as any);
+      await expect(lessonService.createLesson(1, { sectionId: 5, title: 'L1', type: 'VIDEO' } as any))
+        .rejects.toThrow('Section not found');
+    });
+  });
+
+  describe('updateLesson', () => {
+    it('should update lesson when owner', async () => {
+      mockPrisma.lesson.findUnique.mockResolvedValue({ id: 1, section: { course: { id: 10, instructorId: 1 } } } as any);
+      mockPrisma.lesson.update.mockResolvedValue({ id: 1, title: 'Updated' } as any);
+      const res = await lessonService.updateLesson(1, 1, { title: 'Updated' } as any);
+      expect(res.title).toBe('Updated');
+    });
+  });
+
+  describe('deleteLesson', () => {
+    it('should delete lesson when owner', async () => {
+      mockPrisma.lesson.findUnique.mockResolvedValue({ id: 1, section: { course: { id: 10, instructorId: 1 } } } as any);
+      mockPrisma.lesson.delete.mockResolvedValue({ id: 1 } as any);
+      await lessonService.deleteLesson(1, 1);
+      expect(mockPrisma.lesson.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    });
+  });
+
+  describe('reorderLessons', () => {
+    it('should reorder when owner', async () => {
+      mockPrisma.section.findUnique.mockResolvedValue({ course: { instructorId: 1 } } as any);
+      mockPrisma.$transaction.mockResolvedValue([] as any);
+      await lessonService.reorderLessons(99, 1, [7, 8]);
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+  });
+});
+

--- a/services/course-service/src/__tests__/unit/services/section.service.test.ts
+++ b/services/course-service/src/__tests__/unit/services/section.service.test.ts
@@ -1,0 +1,85 @@
+import { mockPrisma } from '../../setup/mock.setup';
+import * as sectionService from '../../../services/section.service';
+import { mockSection } from '../../setup/fixtures';
+
+describe('Section Service - Unit Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createSection', () => {
+    it('should create section and compute order when missing', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ instructorId: 1 } as any);
+      mockPrisma.section.findFirst.mockResolvedValue(null as any);
+      mockPrisma.section.aggregate.mockResolvedValue({ _max: { order: 2 } } as any);
+      const expected = mockSection({ id: 1, order: 3 });
+      mockPrisma.section.create.mockResolvedValue({ ...expected, lessons: [] } as any);
+
+      const result = await sectionService.createSection(1, { courseId: 10, title: 'S1' });
+
+      expect(mockPrisma.section.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ order: 3 }) })
+      );
+      expect(result.id).toBe(1);
+    });
+
+    it('should reject when not course owner', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ instructorId: 2 } as any);
+      await expect(sectionService.createSection(1, { courseId: 10, title: 'S1' }))
+        .rejects.toThrow('Not authorized');
+    });
+
+    it('should reject when course not found', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(null as any);
+      await expect(sectionService.createSection(1, { courseId: 10, title: 'S1' }))
+        .rejects.toThrow('Course not found');
+    });
+  });
+
+  describe('updateSection', () => {
+    it('should update when owner', async () => {
+      const section = { id: 1, course: { instructorId: 1 } } as any;
+      mockPrisma.section.findUnique.mockResolvedValue(section);
+      const updated = { ...section, title: 'Updated' } as any;
+      mockPrisma.section.update.mockResolvedValue(updated);
+
+      const result = await sectionService.updateSection(1, 1, { title: 'Updated' } as any);
+
+      expect(mockPrisma.section.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 1 }, data: { title: 'Updated' } })
+      );
+      expect(result.title).toBe('Updated');
+    });
+
+    it('should throw when not owner', async () => {
+      mockPrisma.section.findUnique.mockResolvedValue({ course: { instructorId: 2 } } as any);
+      await expect(sectionService.updateSection(1, 1, { title: 'X' } as any)).rejects.toThrow('Not authorized');
+    });
+
+    it('should throw when section not found', async () => {
+      mockPrisma.section.findUnique.mockResolvedValue(null as any);
+      await expect(sectionService.updateSection(1, 1, { title: 'X' } as any)).rejects.toThrow('Section not found');
+    });
+  });
+
+  describe('deleteSection', () => {
+    it('should delete when owner', async () => {
+      mockPrisma.section.findUnique.mockResolvedValue({ id: 1, course: { instructorId: 1 } } as any);
+      mockPrisma.section.delete.mockResolvedValue({ id: 1 } as any);
+      await sectionService.deleteSection(1, 1);
+      expect(mockPrisma.section.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    });
+  });
+
+  describe('reorderSections', () => {
+    it('should reorder when owner', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ instructorId: 1 } as any);
+      mockPrisma.$transaction.mockResolvedValue([] as any);
+
+      await sectionService.reorderSections(10, 1, [3, 2, 1]);
+
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+  });
+});
+

--- a/services/course-service/src/controllers/category.controller.ts
+++ b/services/course-service/src/controllers/category.controller.ts
@@ -1,9 +1,22 @@
 import type { Request, Response } from "express";
 import * as categoryService from "../services/category.service";
-import { ApiError, catchAsync } from "@shared";
+import { ApiError, catchAsync, delByPrefix } from "@shared";
+
+const clearCategoryCaches = async (categoryId?: number, categorySlug?: string) => {
+  const tasks: Promise<any>[] = [];
+
+  if (categoryId) tasks.push(delByPrefix(`categories:detail:/categories/${categoryId}`))
+  if (categorySlug) tasks.push(delByPrefix(`categories:detail:/categories/${categorySlug}`))
+
+  tasks.push(delByPrefix("categories:list"))
+  tasks.push(delByPrefix("categories:root"))
+
+  await Promise.allSettled(tasks)
+}
 
 export const createCategory = catchAsync(async (req: Request, res: Response) => {
   const category = await categoryService.createCategory(req.body);
+  await clearCategoryCaches()
   return res.success({ category }, "Category created", 201);
 });
 
@@ -41,12 +54,14 @@ export const getCategory = catchAsync(async (req: Request, res: Response) => {
 
 export const updateCategory = catchAsync(async (req: Request, res: Response) => {
   const categoryId = parseInt(req.params.id);
-  const category = await categoryService.updateCategory(categoryId, req.body);
-  return res.success({ category }, "Category updated");
+  const { updated, oldSlug } = await categoryService.updateCategory(categoryId, req.body);
+  await clearCategoryCaches(updated.id, oldSlug)
+  return res.success({ category: updated }, "Category updated");
 });
 
 export const deleteCategory = catchAsync(async (req: Request, res: Response) => {
   const categoryId = parseInt(req.params.id);
   await categoryService.deleteCategory(categoryId);
+  await clearCategoryCaches(categoryId)
   return res.success(null, "Category deleted");
 });

--- a/services/course-service/src/controllers/course.controller.ts
+++ b/services/course-service/src/controllers/course.controller.ts
@@ -1,11 +1,26 @@
 import type { Request, Response } from "express";
 import catchAsync from "@shared/utils/catchAsync";
 import * as courseService from "../services/course.service"
-import { ApiError } from "@shared";
+import { ApiError, delByPrefix } from "@shared";
+
+const clearCourseCaches = async (courseId?: number, courseSlug?: string) => {
+  const tasks: Promise<any>[] = [];
+
+  if (courseId) {
+    tasks.push(delByPrefix(`courses:detail:/${courseId}`));
+    tasks.push(delByPrefix(`sections:list:/${courseId}`));
+  }
+  if (courseSlug) tasks.push(delByPrefix(`courses:detail:/${courseSlug}`));
+
+  tasks.push(delByPrefix("courses:list"))
+
+  await Promise.allSettled(tasks)
+}
 
 export const createCourse = catchAsync(async (req: Request, res: Response) => {
   const instructorId = req.user!.id;
   const course = await courseService.createCourse(instructorId, req.body);
+  await clearCourseCaches()
   return res.success({ course }, "Course created", 201);
 })
 
@@ -66,14 +81,18 @@ export const getInstructorCourses = catchAsync(async (req: Request, res: Respons
 export const updateCourse = catchAsync(async (req: Request, res: Response) => {
   const courseId = parseInt(req.params.id);
   const instructorId = req.user!.id;
-  const course = await courseService.updateCourse(courseId, instructorId, req.body)
-  return res.success({ course }, "Course updated")
+  const { updated, oldSlug } = await courseService.updateCourse(courseId, instructorId, req.body)
+
+  await clearCourseCaches(updated.id, oldSlug)
+
+  return res.success({ course: updated }, "Course updated")
 })
 
 export const deleteCourse = catchAsync(async (req: Request, res: Response) => {
   const courseId = parseInt(req.params.id);
   const instructorId = req.user!.id;
-  await courseService.deleteCourse(courseId, instructorId);
+  const course = await courseService.deleteCourse(courseId, instructorId);
+  await clearCourseCaches(course.id, course.slug)
   return res.success(null, "Course deleted");
 })
 
@@ -81,6 +100,7 @@ export const publishCourse = catchAsync(async (req: Request, res: Response) => {
   const courseId = parseInt(req.params.id);
   const instructorId = req.user!.id;
   const course = await courseService.publishCourse(courseId, instructorId);
+  await clearCourseCaches(course.id, course.slug)
   return res.success({ course }, "Course published");
 })
 
@@ -88,5 +108,6 @@ export const archiveCourse = catchAsync(async (req: Request, res: Response) => {
   const courseId = parseInt(req.params.id);
   const instructorId = req.user!.id;
   const course = await courseService.archiveCourse(courseId, instructorId);
+  await clearCourseCaches(course.id, course.slug)
   return res.success({ course }, "Course archived");
 })

--- a/services/course-service/src/controllers/course.controller.ts
+++ b/services/course-service/src/controllers/course.controller.ts
@@ -34,7 +34,7 @@ export const getAllCourses = catchAsync(async (req: Request, res: Response) => {
     level: req.query.level as any,
     status: "PUBLISHED" as any,
     minPrice: req.query.minPrice ? parseFloat(req.query.minPrice as string) : undefined,
-    maxPrice: req.query.minPrice ? parseFloat(req.query.maxPrice as string) : undefined,
+    maxPrice: req.query.maxPrice ? parseFloat(req.query.maxPrice as string) : undefined,
     tags: req.query.tags ? (req.query.tags as string).split(",") : undefined,
     language: req.query.language as string
   }
@@ -69,7 +69,7 @@ export const getInstructorCourses = catchAsync(async (req: Request, res: Respons
     level: req.query.level as any,
     status: "PUBLISHED" as any,
     minPrice: req.query.minPrice ? parseFloat(req.query.minPrice as string) : undefined,
-    maxPrice: req.query.minPrice ? parseFloat(req.query.maxPrice as string) : undefined,
+    maxPrice: req.query.maxPrice ? parseFloat(req.query.maxPrice as string) : undefined,
     tags: req.query.tags ? (req.query.tags as string).split(",") : undefined,
     language: req.query.language as string
   }

--- a/services/course-service/src/controllers/lesson.controller.ts
+++ b/services/course-service/src/controllers/lesson.controller.ts
@@ -1,11 +1,22 @@
 import type { Request, Response } from "express";
 import catchAsync from "@shared/utils/catchAsync";
 import * as lessonService from "../services/lesson.service";
-import { ApiError } from "@shared";
+import { ApiError, delByPrefix } from "@shared";
+
+const clearLessonCaches = async (lessonId?: number) => {
+  const tasks: Promise<any>[] = [];
+
+  if (lessonId) tasks.push(delByPrefix(`lessons:detail:/lessons/${lessonId}`))
+
+  tasks.push(delByPrefix("lessons:list"))
+
+  await Promise.allSettled(tasks)
+}
 
 export const createLesson = catchAsync(async (req: Request, res: Response) => {
   const instructorId = req.user!.id;
   const lesson = await lessonService.createLesson(instructorId, req.body);
+  await clearLessonCaches()
   return res.success({ lesson }, "Lesson created", 201);
 })
 
@@ -26,6 +37,7 @@ export const updateLesson = catchAsync(async (req: Request, res: Response) => {
   const lessonId = parseInt(req.params.id);
   const instructorId = req.user!.id;
   const lesson = await lessonService.updateLesson(lessonId, instructorId, req.body);
+  await clearLessonCaches(lessonId)
   return res.success({ lesson }, "Lesson updated");
 })
 
@@ -33,6 +45,7 @@ export const deleteLesson = catchAsync(async (req: Request, res: Response) => {
   const lessonId = parseInt(req.params.id);
   const instructorId = req.user!.id;
   await lessonService.deleteLesson(lessonId, instructorId)
+  await clearLessonCaches(lessonId)
   return res.success(null, "Lesson deleted");
 })
 
@@ -41,5 +54,6 @@ export const reorderLesson = catchAsync(async (req: Request, res: Response) => {
   const instructorId = req.user!.id;
   const { lessonIds } = req.body;
   await lessonService.reorderLessons(sectionId, instructorId, lessonIds);
+  await clearLessonCaches()
   return res.success(null, "Lessons reordered");
 })

--- a/services/course-service/src/controllers/section.controller.ts
+++ b/services/course-service/src/controllers/section.controller.ts
@@ -1,11 +1,25 @@
 import type { Request, Response } from "express";
 import catchAsync from "@shared/utils/catchAsync";
 import * as sectionService from "../services/section.service"
-import { ApiError } from "@shared";
+import { ApiError, delByPrefix } from "@shared";
+
+const clearSectionCaches = async (sectionId?: number) => {
+  const tasks: Promise<any>[] = [];
+
+  if (sectionId) {
+    tasks.push(delByPrefix(`sections:detail:/sections/${sectionId}`))
+    tasks.push(delByPrefix(`lessons:list:/sections/${sectionId}`))
+  }
+
+  tasks.push(delByPrefix("sections:list"))
+
+  await Promise.allSettled(tasks)
+}
 
 export const createSection = catchAsync(async (req: Request, res: Response) => {
   const instructorId = req.user!.id;
   const section = await sectionService.createSection(instructorId, req.body)
+  await clearSectionCaches()
   return res.success({ section }, "Section created", 201);
 });
 
@@ -26,6 +40,7 @@ export const updateSection = catchAsync(async (req: Request, res: Response) => {
   const sectionId = parseInt(req.params.id);
   const instructorId = req.user!.id;
   const section = await sectionService.updateSection(sectionId, instructorId, req.body)
+  await clearSectionCaches(section.id)
   return res.success({ section }, "Section updated");
 })
 
@@ -33,6 +48,7 @@ export const deleteSection = catchAsync(async (req: Request, res: Response) => {
   const sectionId = parseInt(req.params.id);
   const instructorId = req.user!.id;
   await sectionService.deleteSection(sectionId, instructorId)
+  await clearSectionCaches(sectionId)
   return res.success(null, "Section deleted");
 })
 
@@ -41,5 +57,6 @@ export const reorderSection = catchAsync(async (req: Request, res: Response) => 
   const instructorId = req.user!.id;
   const { sectionIds } = req.body;
   await sectionService.reorderSections(courseId, instructorId, sectionIds)
+  await clearSectionCaches()
   return res.success(null, "Sections reordered");
 })

--- a/services/course-service/src/db/client.ts
+++ b/services/course-service/src/db/client.ts
@@ -11,8 +11,16 @@ type PrismaClient = InstanceType<typeof PrismaPkg.PrismaClient>;
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
+const resolveDbUrl = () =>
+  process.env.DATABASE_URL || process.env.COURSE_DATABASE_URL || undefined;
+
 const prisma = (globalForPrisma.prisma ?? new PrismaPkg.PrismaClient({
   log: process.env.NODE_ENV === "production" ? ["error"] : ["error", "warn"],
+  datasources: {
+    db: {
+      url: resolveDbUrl(),
+    },
+  },
 })) as PrismaClient;
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/services/course-service/src/routes/category.route.ts
+++ b/services/course-service/src/routes/category.route.ts
@@ -15,7 +15,7 @@ categoryRouter.get(
 
 categoryRouter.get(
   "/categories/root",
-  cache({ prefix: "categories: root", ttl: 600 }),
+  cache({ prefix: "categories:root", ttl: 600 }),
   categoryController.getRootCategories
 )
 

--- a/services/course-service/src/routes/lesson.route.ts
+++ b/services/course-service/src/routes/lesson.route.ts
@@ -7,6 +7,12 @@ import * as validations from "../validations/lesson.validation"
 const lessonRouter: RouterType = Router()
 
 lessonRouter.get(
+  "/sections/:sectionId/lessons",
+  cache({ prefix: "lessons:list", ttl: 300 }),
+  lessonController.getSectionLessons
+);
+
+lessonRouter.get(
   "/lessons/:id",
   cache({ prefix: "lessons:detail", ttl: 300 }),
   lessonController.getLessonById

--- a/services/course-service/src/routes/section.route.ts
+++ b/services/course-service/src/routes/section.route.ts
@@ -12,6 +12,12 @@ sectionRouter.get(
   sectionController.getCourseSections
 )
 
+sectionRouter.get(
+  "/sections/:id",
+  cache({ prefix: "sections:detail", ttl: 300 }),
+  sectionController.getSectionById
+);
+
 sectionRouter.post(
   "/sections",
   auth(["INSTRUCTOR", "ADMIN"]),

--- a/services/course-service/src/services/category.service.ts
+++ b/services/course-service/src/services/category.service.ts
@@ -1,8 +1,8 @@
 import ApiError from "@shared/utils/ApiError";
 import { generateSlug } from "@shared/utils/slug";
-import prisma from "src/db/client";
+import prisma from "../db/client";
 import { Category } from "@prisma/client"
-import { CategoryFilters, CategoryWithRelations, CreateCategoryRequest, UpdateCategoryRequest } from "src/types";
+import { CategoryFilters, CategoryWithRelations, CreateCategoryRequest, UpdateCategoryRequest } from "../types";
 
 const ensureUniqueSlug = async (baseSlug: string, excluded?: number): Promise<string> => {
   let slug = baseSlug;

--- a/services/course-service/src/services/category.service.ts
+++ b/services/course-service/src/services/category.service.ts
@@ -142,9 +142,10 @@ export const getAllCategories = async (filters: CategoryFilters) => {
   }
 }
 
-export const updateCategory = async (id: number, data: UpdateCategoryRequest): Promise<CategoryWithRelations> => {
+export const updateCategory = async (id: number, data: UpdateCategoryRequest): Promise<{ updated: CategoryWithRelations, oldSlug: string }> => {
   const category = await prisma.category.findUnique({ where: { id } });
   if (!category) throw ApiError.notFound("Category not found");
+  const oldSlug = category.slug
 
   if (data.parentId) {
     if (data.parentId === id) {
@@ -173,7 +174,7 @@ export const updateCategory = async (id: number, data: UpdateCategoryRequest): P
     }
   })
 
-  return updated
+  return { updated, oldSlug }
 }
 
 export const deleteCategory = async (id: number): Promise<void> => {

--- a/services/course-service/src/services/course.service.ts
+++ b/services/course-service/src/services/course.service.ts
@@ -1,6 +1,6 @@
 import prisma from "../db/client";
 import { ApiError, generateSlug } from "@shared";
-import { CourseFilters, CourseWithRelations, CreateCourseRequest, SectionWithLessons, UpdateCourseRequest } from "src/types";
+import { CourseFilters, CourseWithRelations, CreateCourseRequest, SectionWithLessons, UpdateCourseRequest } from "../types";
 
 
 const ensureUniqueSlug = async (baseSlug: string, excludeId?: number): Promise<string> => {
@@ -8,7 +8,7 @@ const ensureUniqueSlug = async (baseSlug: string, excludeId?: number): Promise<s
   let counter = 1;
 
   while (true) {
-    const existing = await prisma.course.findUnique({
+    const existing = await prisma.course.findFirst({
       where: { slug },
       select: { id: true }
     });

--- a/services/course-service/src/services/course.service.ts
+++ b/services/course-service/src/services/course.service.ts
@@ -156,8 +156,9 @@ export const updateCourse = async (
   id: number,
   instructorId: number,
   data: UpdateCourseRequest
-): Promise<CourseWithRelations> => {
+): Promise<{ updated: CourseWithRelations, oldSlug: string }> => {
   const course = await validateAndGetCourse(id, instructorId)
+  const oldSlug = course.slug
 
   const updateData: any = { ...data }
 
@@ -178,13 +179,13 @@ export const updateCourse = async (
     }
   })
 
-  return updated;
+  return { updated, oldSlug };
 }
 
-export const deleteCourse = async (id: number, instructorId: number): Promise<void> => {
-  await validateAndGetCourse(id, instructorId)
-
+export const deleteCourse = async (id: number, instructorId: number): Promise<CourseWithRelations> => {
+  const course = await validateAndGetCourse(id, instructorId)
   await prisma.course.delete({ where: { id } });
+  return course;
 }
 
 export const publishCourse = async (id: number, instructorId: number): Promise<CourseWithRelations> => {

--- a/services/course-service/src/services/enrollment.service.ts
+++ b/services/course-service/src/services/enrollment.service.ts
@@ -1,5 +1,5 @@
-import prisma from "src/db/client";
-import { CreateEnrollmentRequest, EnrollmentFilters, UpdateEnrollmentRequest } from "src/types";
+import prisma from "../db/client";
+import { CreateEnrollmentRequest, EnrollmentFilters, UpdateEnrollmentRequest } from "../types";
 import { ApiError } from "@shared"
 import { Enrollment } from "@prisma/client";
 

--- a/services/course-service/src/services/lesson.service.ts
+++ b/services/course-service/src/services/lesson.service.ts
@@ -1,6 +1,6 @@
 import ApiError from "@shared/utils/ApiError";
-import prisma from "src/db/client";
-import { CreateLessonRequest, UpdateLessonRequest } from "src/types";
+import prisma from "../db/client";
+import { CreateLessonRequest, UpdateLessonRequest } from "../types";
 import { calculateCourseDuration } from "./course.service";
 import { Lesson } from "@prisma/client";
 

--- a/services/course-service/src/services/section.service.ts
+++ b/services/course-service/src/services/section.service.ts
@@ -1,6 +1,6 @@
 import { ApiError } from "@shared";
-import prisma from "src/db/client";
-import { CreateSectionRequest, SectionWithLessons, UpdateSectionRequest } from "src/types";
+import prisma from "../db/client";
+import { CreateSectionRequest, SectionWithLessons, UpdateSectionRequest } from "../types";
 
 export const createSection = async (
   instructorId: number,

--- a/services/course-service/tsconfig.json
+++ b/services/course-service/tsconfig.json
@@ -22,10 +22,14 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "composite": true,
-    "incremental": true
+    "incremental": true,
+    "isolatedModules": true
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
   "references": [
     { "path": "../../shared" }
   ]

--- a/shared/src/middlewares/validate.ts
+++ b/shared/src/middlewares/validate.ts
@@ -54,7 +54,11 @@ const validate = (schema: SchemaShape) => (req: Request, _res: Response, next: N
     }
 
     // assign the sanitized value back to the request
-    (req as any)[key] = value;
+    if (key === 'query' || key === 'params' || key === 'headers') {
+      Object.assign((req as any)[key] || {}, value);
+    } else {
+      (req as any)[key] = value;
+    }
   }
 
   if (errors.length) return next(ApiError.badRequest(errors.join(", ")));


### PR DESCRIPTION
### Summary
This PR adds the Course Service module to the mini-udemy-microservices project.  
Includes business logic, caching, and automated tests for core course functionality.

### Changes
- Implemented Course Service with full CRUD operations.
- Added cache clearing for courses, sections, lessons, and categories.
- Integrated Redis for caching.
- Added seed data for testing (`seed.ts`).
- Added integration and unit tests to ensure feature reliability.
- Updated `pnpm-lock.yaml` with new dependencies.

### Testing
- All tests run successfully with `pnpm test`.
- Verified caching and clearing mechanisms work as expected.

